### PR TITLE
Fix handling of responses with an empty body

### DIFF
--- a/lib/connect-injector.js
+++ b/lib/connect-injector.js
@@ -65,7 +65,7 @@ module.exports = function(when, converter) {
 					this.write(data);
 				}
 
-				if(!isIntercepted) {
+				if(!interceptCheck.call(this)) {
 					return this.old.end.apply(this);
 				}
 

--- a/test/injector_tests.js
+++ b/test/injector_tests.js
@@ -26,6 +26,28 @@ describe('connect-injector', function () {
 		});
 	});
 
+	it('does not mess with empty responses', function (done) {
+		var rewriter = injector(function () {
+			return false;
+		}, function () {
+			done('Should never be called');
+		});
+
+		var app = connect().use(rewriter).use(function (req, res) {
+			res.writeHead(204, {'Content-Length': '0'});
+			res.end();
+		});
+
+		var server = app.listen(9999).on('listening', function () {
+			request('http://localhost:9999', function (error, response, body) {
+				should.not.exist(error);
+				should.not.exist(body);
+				response.statusCode.should.equal(204);
+				server.close(done);
+			});
+		});
+	});
+
 	it('does some basic rewriting', function (done) {
 		var REWRITTEN = 'Hello People';
 		var rewriter = injector(function (req, res) {


### PR DESCRIPTION
Without this change the injector causes 'undefined' string to be returned (with no headers and not status code) instead of an empty response (for example 204: no content).

Wireshark dump:

DELETE /foo/bar/ HTTP/1.1
Host: localhost:3000
Accept: _/_
Accept-Language: en-US,en;q=0.5
Accept-Encoding: gzip, deflate
Connection: keep-alive

undefined
