### PR TITLE
Add debug messages and fix for running with Node 0.10.32.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,5 @@
 language: node_js
-node_js: 0.10
+node_js:
+  - 0.10.31
+  - 0.10.32
+  - 0.11

--- a/lib/connect-injector.js
+++ b/lib/connect-injector.js
@@ -10,24 +10,15 @@ var _ = require('underscore');
 var Proto = require('uberproto');
 var zlib = require('zlib');
 var Q = require('q');
+var debug = require('debug')('connect-injector');
 
 var WritableStream = require('stream-buffers').WritableStreamBuffer;
-var headerExp = /^([^:]+): *(.*)$/;
-var parseHeaders = function (headers) {
-  var result = {};
-  headers.split('\r\n').forEach(function (line) {
-    var match = headerExp.exec(line);
-    if (match && match[1] && match[2]) {
-      result[match[1].toLowerCase()] = match[2];
-    }
-  });
-  return result;
-};
 
 module.exports = function (when, converter) {
   return function (req, res, next) {
     // Allows more than one injector
     if (res.injectors) {
+      debug('injector already initialized, adding to existing');
       res.injectors.push({
         when: when,
         converter: converter
@@ -35,6 +26,9 @@ module.exports = function (when, converter) {
       return next();
     }
 
+    debug('initializing new injector');
+
+    var oldWrite = res.write;
     // An object that we can mix into the response
     var mixin = {
       injectors: [
@@ -43,6 +37,7 @@ module.exports = function (when, converter) {
           converter: converter
         }
       ],
+
       // Checks if this response should be intercepted
       _interceptCheck: function () {
         var self = this;
@@ -58,87 +53,70 @@ module.exports = function (when, converter) {
           if (!this._isIntercepted) {
             this._isIntercepted = false;
           }
+          debug('first time _interceptCheck ran', this._isIntercepted);
         }
         return this._isIntercepted;
       },
+
       // Overwrite setting the response headers. We can't do content-length
       // so lets just use transfer-encoding chunked
       setHeader: function (name, value) {
         if (name === 'content-length' || name === 'Content-Length') {
-          name = 'transfer-encoding';
-          value = 'chunked';
+          debug('not setting content-length header');
+          return;
         }
 
         return this._super(name, value);
       },
+
       // Overwrite writeHead since it can also set the headers and we need to override
       // the transfer-encoding
       writeHead: function(status, reasonPhrase, headers) {
-        var mappedHeaders = {};
+        var self = this;
 
         _.each(headers || reasonPhrase, function(value, name) {
-          name = name.toLowerCase();
-
-          if (name === 'content-length') {
-            name = 'transfer-encoding';
-            value = 'chunked';
-          }
-
-          mappedHeaders[name] = value;
+          self.setHeader(name, value);
         });
 
-        this._actualHeaders = mappedHeaders;
-
-        if(headers) {
-          return this._super(status, reasonPhrase, mappedHeaders);
-        }
-
-        return this._super(status, mappedHeaders);
+        return this._super(status, typeof reasonPhrase === 'string' ? reasonPhrase : undefined);
       },
-      // Returns the header even if it originally hasn't been set by parsing res._header
-      getHeader: function (name) {
-        var _super = this._super.apply(this, arguments);
 
-        if (_super || !this._header) {
-          return _super;
-        }
-
-        if(this._header) {
-          this._actualHeaders = _.extend({}, this._actualHeaders, parseHeaders(this._header));
-        }
-
-        return this._actualHeaders[name.toLowerCase()];
-      },
       // Write into the buffer if this request is intercepted
-      write: function (chunk) {
+      write: function (chunk, encoding) {
         if (this._interceptCheck()) {
           if(!this._interceptBuffer) {
+            debug('initializing _interceptBuffer');
             this._interceptBuffer = new WritableStream();
           }
 
-          this._interceptBuffer.write(chunk);
-          return true;
+          return this._interceptBuffer.write(chunk, encoding);
         }
 
         return this._super.apply(this, arguments);
       },
+
       // End the request.
-      end: function (data) {
+      end: function (data, encoding) {
         var self = this;
         var _super = this._super.bind(this);
 
-        if (data) {
-          this.write(data);
+        if (!this._interceptCheck()) {
+          debug('not intercepting, ending with original .end');
+          return _super(data, encoding);
         }
 
-        if (!this._isIntercepted) {
-          return _super();
+        if (data) {
+          this.write(data, encoding);
         }
+
+        debug('resetting to original response.write');
+        this.write = oldWrite;
 
         var gzipped = this.getHeader('content-encoding') === 'gzip';
         var chain = Q(this._interceptBuffer.getContents());
 
         if(gzipped) {
+          debug('unzipping content');
           // Unzip the buffer
           chain = chain.then(function(buffer) {
             return Q.nfcall(zlib.gunzip, buffer);
@@ -149,6 +127,7 @@ module.exports = function (when, converter) {
           // Run all converters, if they are active
           // In series, using the previous output
           if(injector.active) {
+            debug('adding injector to chain');
             var converter = injector.converter.bind(self);
             chain = chain.then(function(prev) {
               return Q.nfcall(converter, prev, req, res);
@@ -157,6 +136,7 @@ module.exports = function (when, converter) {
         });
 
         if(gzipped) {
+          debug('re-zipping content');
           // Zip it again
           chain = chain.then(function(result) {
             return Q.nfcall(zlib.gzip, result);
@@ -164,6 +144,7 @@ module.exports = function (when, converter) {
         }
 
         chain.then(_super).fail(function(e) {
+          debug('injector chain failed, emitting error event');
           self.emit('error', e);
         });
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "connect": "^2.7.2",
+    "debug": "^2.0.0",
     "q": "^1.0.1",
     "stream-buffers": "^0.2.3",
     "uberproto": "^1.1.0",


### PR DESCRIPTION
This pull request makes connect-injector work with Node 0.10.32 and closes #11. Also adds debug messages and removes the clunky header rewriting (after reading the Node HTTP code it turned out that you just have to not set `content-length` to get chunked encoding by default).

The actual fix was to re-set to the original `res.write` when ending the response.
