### PR TITLE
Empty responses should not be injected even if matching.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ to see the injected content.
 
 ## Release History
 
+__0.4.2__
+
+- Fix for empty responses not trying to be rewritten ([#13](https://github.com/daffl/connect-injector/issues/13), [#14](https://github.com/daffl/connect-injector/pull/14))
+
 __0.4.1__
 
 - Fix connect-injector to work with Node 0.10.32 ([#11](https://github.com/daffl/connect-injector/pull/11))

--- a/lib/connect-injector.js
+++ b/lib/connect-injector.js
@@ -112,6 +112,12 @@ module.exports = function (when, converter) {
         debug('resetting to original response.write');
         this.write = oldWrite;
 
+        // Responses without a body can just be ended
+        if(!this._hasBody || !this._interceptBuffer) {
+          debug('ending empty resopnse without injecting anything');
+          return _super();
+        }
+
         var gzipped = this.getHeader('content-encoding') === 'gzip';
         var chain = Q(this._interceptBuffer.getContents());
 

--- a/test/injector_tests.js
+++ b/test/injector_tests.js
@@ -36,7 +36,7 @@ describe('connect-injector', function() {
     });
 
     var app = connect().use(rewriter).use(function(req, res) {
-      res.writeHead(204, {'Content-Length': '0'});
+      res.writeHead(204);
       res.end();
     });
 
@@ -45,6 +45,28 @@ describe('connect-injector', function() {
         should.not.exist(error);
         should.not.exist(body);
         response.statusCode.should.equal(204);
+        server.close(done);
+      });
+    });
+  });
+
+  it('works with empty responses that are rewritten', function(done) {
+    var rewriter = injector(function() {
+      return true;
+    }, function() {
+      done('Should never be called');
+    });
+
+    var app = connect().use(rewriter).use(function(req, res) {
+      res.writeHead(304);
+      res.end();
+    });
+
+    var server = app.listen(9999).on('listening', function() {
+      request('http://localhost:9999', function(error, response, body) {
+        should.not.exist(error);
+        should.not.exist(body);
+        response.statusCode.should.equal(304);
         server.close(done);
       });
     });


### PR DESCRIPTION
This closes #13. We should not try injecting into empty responses (like 304), even if the check returns true.
